### PR TITLE
CORS is fixed. Please see description

### DIFF
--- a/application-backend/application-controller.mjs
+++ b/application-backend/application-controller.mjs
@@ -40,11 +40,27 @@ const creds = { key: privateKey, cert: certificate, passphrase: passphrase };
 const httpsServer = https.createServer(creds, app);
 
 
-// Enable CORS for all routes and origins
-// app.use(cors({ origin: 'https://localhost:3000', credentials: true }));
+//Added local laptop IP for testing from different computers in my network
+//CORS is VERY picky about the origin IP; app.use(cors()) is not strict enough when dealing with any sort of cookie
+//which is the reason why localhost worked, and 127.0.0.1 didn't and vice-versa.
+//allowed origins will EVENTUALLY have our domain name at port 443 once we host!
+const allowedOrigins = ['https://localhost:3000', 'https://127.0.0.1:3000', 'https://192.168.88.79:3000']
 
-app.use(cors());
+app.use(cors({
+    origin: function (origin, callback) {
+        // Check if the origin is in the list of allowed origins or if it's a browser preflight request
+        const isAllowed = allowedOrigins.some(allowedOrigin =>
+            new RegExp(allowedOrigin).test(origin)
+        );
 
+        if (isAllowed || !origin) {
+            callback(null, true);
+        } else {
+            callback(new Error('Not allowed by CORS'));
+        }
+    },
+    credentials: true,
+}));
 
 const userRouter = express.Router();
 const loginItemRouter = express.Router();

--- a/application-microservices/jwt-microservice/jwt-controller.mjs
+++ b/application-microservices/jwt-microservice/jwt-controller.mjs
@@ -42,9 +42,9 @@ app.use(express.json());
 app.use(cookieparser());
 
 // Enable All CORS Requests
-// app.use(cors({ origin: 'https://localhost:3000', credentials: true }));
+app.use(cors({ origin: 'https://localhost:3000', credentials: true }));
 
-app.use(cors());
+// app.use(cors());
 
 app.get('/jwt-api', cors(), async (req, res) => {
     res.status(200).json({ message: 'Welcome to jwt-controller!' });

--- a/application-microservices/two-factor-authentication-code-microservice/two-factor-authentication-code-controller.mjs
+++ b/application-microservices/two-factor-authentication-code-microservice/two-factor-authentication-code-controller.mjs
@@ -48,7 +48,23 @@ app.use(express.json());
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 // Enable All CORS Requests from any origin and allow server to accept cookies from client
-app.use(cors({ origin: 'https://localhost:3000', credentials: true }));
+const allowedOrigins = ['https://localhost:3000', 'https://127.0.0.1:3000', 'https://107.181.189.57:7263', 'https://192.168.88.79:3000'];
+
+app.use(cors({
+    origin: function (origin, callback) {
+        // Check if the origin is in the list of allowed origins or if it's a browser preflight request
+        const isAllowed = allowedOrigins.some(allowedOrigin =>
+            new RegExp(allowedOrigin).test(origin)
+        );
+
+        if (isAllowed || !origin) {
+            callback(null, true);
+        } else {
+            callback(new Error('Not allowed by CORS'));
+        }
+    },
+    credentials: true,
+}));
 
 
 app.get('/api', checkAuth, (req, res) => {

--- a/application-microservices/user-login-microservice/user-login-controller.mjs
+++ b/application-microservices/user-login-microservice/user-login-controller.mjs
@@ -43,15 +43,34 @@ app.use(express.json());
 app.use(cookieparser());
 
 // Enable COR requests from localhost:3000 only
+
+//Added local laptop IP for testing from different computers in my network
+//CORS is VERY picky about the origin IP; app.use(cors()) is not strict enough when dealing with any sort of cookie
+//which is the reason why localhost worked, and 127.0.0.1 didn't and vice-versa.
+//allowed origins will EVENTUALLY have our domain name at port 443 once we host!
+const allowedOrigins = ['https://localhost:3000', 'https://127.0.0.1:3000', 'https://192.168.88.79:3000']
+
 app.use(cors({
-    origin: 'https://localhost:3000', // Replace with frontend's actual domain later
-    credentials: true
+    origin: function (origin, callback) {
+        // Check if the origin is in the list of allowed origins or if it's a browser preflight request
+        const isAllowed = allowedOrigins.some(allowedOrigin =>
+            new RegExp(allowedOrigin).test(origin)
+        );
+
+        if (isAllowed || !origin) {
+            callback(null, true);
+        } else {
+            callback(new Error('Not allowed by CORS'));
+        }
+    },
+    credentials: true,
 }));
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 
 app.post('/login/validation', async (req, res) => {
+    console.log(req)
     const { username, password } = req.body;
 
     if (!username || !password) {


### PR DESCRIPTION
CORS (Cross Origin Resource Sharing) is extremely picky when it comes to accepting origins when credentials/cookies are involved. This is why` app.use(cors()) ` did not work in the app controller, or the controllers for login and jwt services. These changes will need to be put in place elsewhere wherever cookies are involved.

cors is so picky when cookies are involved that 127.0.0.1:3000 was denied as an origin, but localhost:3000 WORKED. Bizarre, but it's more secure that way.

We will eventually put the domain we're hosting at in the allowedOrigins array.

@EugenSong 